### PR TITLE
Extend storage options

### DIFF
--- a/spec/001-initialization.js
+++ b/spec/001-initialization.js
@@ -84,7 +84,7 @@ describe('ConstructorioID', function () {
       expect(document.cookie).to.equal('dummyname=dummyid');
     });
 
-    it('should read the client id from the new cookie', function () {
+    it('should read the client id from the default cookie name', function () {
       document.cookie = 'ConstructorioID_client_id=bummyid; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/';
       var session = new ConstructorioID();
       expect(session.client_id).to.equal('bummyid');
@@ -104,7 +104,7 @@ describe('ConstructorioID', function () {
       expect(window.localStorage.getItem('dummyname')).to.equal('dummyid');
     });
 
-    it('should read the client id from the default local storage key and storage location is set to local', function () {
+    it('should read the client id from the default local storage name and storage location is set to local', function () {
       window.localStorage.setItem('_constructorio_search_client', 'bummyid');
       var session = new ConstructorioID({ client_id_storage_location: 'local' });
       expect(session.client_id).to.equal('bummyid');
@@ -133,6 +133,19 @@ describe('ConstructorioID', function () {
       expect(session.session_id).to.equal(1);
     });
 
+    it('should read the session id from cookie and storage location is set to cookie', function () {
+      document.cookie = `ConstructorioID_session_id={"sessionId":42,"lastTime":${Date.now()}}; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/`;
+      var session = new ConstructorioID({ session_id_storage_location: 'cookie' });
+      expect(session.session_id).to.be.a('number');
+      expect(session.session_id).to.equal(42);
+    });
+
+    it('should set the session id to 1 if there is no cookie and storage location is set to cookie', function () {
+      var session = new ConstructorioID({ session_id_storage_location: 'cookie' });
+      expect(session.session_id).to.be.a('number');
+      expect(session.session_id).to.equal(1);
+    });
+
     it('should set session_is_new to false if the session is not new', function () {
       window.localStorage.setItem('_constructorio_search_session', JSON.stringify({
         sessionId: 42,
@@ -150,6 +163,22 @@ describe('ConstructorioID', function () {
         lastTime: Date.now() - 1000 * 60 * 60 * 24 * 60
       }));
       var session = new ConstructorioID();
+      expect(session.session_id).to.equal(43);
+      expect(session.session_is_new).to.be.a('boolean');
+      expect(session.session_is_new).to.equal(true);
+    });
+
+    it('should set session_is_new to false if the session is not new and storage location is set to cookie', function () {
+      document.cookie = `ConstructorioID_session_id={"sessionId":42,"lastTime":${Date.now()}}; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/`;
+      var session = new ConstructorioID({ session_id_storage_location: 'cookie' });
+      expect(session.session_id).to.equal(42);
+      expect(session.session_is_new).to.be.a('boolean');
+      expect(session.session_is_new).to.equal(false);
+    });
+
+    it('should set session_is_new to true if the session is new and storage location is set to cookie', function () {
+      document.cookie = `ConstructorioID_session_id={"sessionId":42,"lastTime":${Date.now() - 1000 * 60 * 60 * 24 * 60}}; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/`;
+      var session = new ConstructorioID({ session_id_storage_location: 'cookie' });
       expect(session.session_id).to.equal(43);
       expect(session.session_is_new).to.be.a('boolean');
       expect(session.session_is_new).to.equal(true);

--- a/spec/001-initialization.js
+++ b/spec/001-initialization.js
@@ -9,7 +9,6 @@ describe('ConstructorioID', function () {
     var expectedKeys = [
       'set_cookie',
       'get_cookie',
-      'update_cookie',
       'delete_cookie',
       'generate_client_id',
       'get_local_object',
@@ -83,13 +82,6 @@ describe('ConstructorioID', function () {
       var session = new ConstructorioID({ cookie_name_client_id: 'dummyname' });
       expect(session.client_id).to.equal('dummyid');
       expect(document.cookie).to.equal('dummyname=dummyid');
-    });
-
-    it('should read the client id from the old cookie', function () {
-      document.cookie = 'ConstructorioAB_client_id=tummyid; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/';
-      var session = new ConstructorioID();
-      expect(session.client_id).to.equal('tummyid');
-      expect(document.cookie).to.equal('ConstructorioID_client_id=tummyid');
     });
 
     it('should read the client id from the new cookie', function () {

--- a/spec/001-initialization.js
+++ b/spec/001-initialization.js
@@ -22,8 +22,8 @@ describe('ConstructorioID', function () {
     var session = new ConstructorioID();
     expect(session.user_agent).to.be.null;
     expect(session.persist).to.be.true;
-    expect(session.cookie_name_client_id).to.equal('ConstructorioID_client_id');
-    expect(session.cookie_name_session_id).to.equal('ConstructorioID_session_id');
+    expect(session.client_id_cookie_name).to.equal('ConstructorioID_client_id');
+    expect(session.session_id_cookie_name).to.equal('ConstructorioID_session_id');
     expect(session.local_name_client_id).to.equal('_constructorio_search_client');
     expect(session.local_name_session_id).to.equal('_constructorio_search_session');
     expect(session.client_id_storage_location).to.equal('cookie');
@@ -38,8 +38,8 @@ describe('ConstructorioID', function () {
       user_agent: 'dummyagent',
       timeout: 1,
       persist: false,
-      cookie_name_client_id: 'dummyclientname',
-      cookie_name_session_id: 'dummysessionname',
+      client_id_cookie_name: 'dummyclientname',
+      session_id_cookie_name: 'dummysessionname',
       local_name_client_id: 'dummyclientnamelocal',
       local_name_session_id: 'dummysessionnamelocal',
       cookie_prefix_for_experiment: 'dummyprefix',
@@ -52,8 +52,8 @@ describe('ConstructorioID', function () {
     expect(session.user_agent).to.equal('dummyagent');
     expect(session.timeout).to.equal(1);
     expect(session.persist).to.be.false;
-    expect(session.cookie_name_client_id).to.equal('dummyclientname');
-    expect(session.cookie_name_session_id).to.equal('dummysessionname');
+    expect(session.client_id_cookie_name).to.equal('dummyclientname');
+    expect(session.session_id_cookie_name).to.equal('dummysessionname');
     expect(session.local_name_client_id).to.equal('dummyclientnamelocal');
     expect(session.local_name_session_id).to.equal('dummysessionnamelocal');
     expect(session.cookie_prefix_for_experiment).to.equal('dummyprefix');
@@ -79,12 +79,12 @@ describe('ConstructorioID', function () {
 
     it('should read the client id from a named cookie', function () {
       document.cookie = 'dummyname=dummyid; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/';
-      var session = new ConstructorioID({ cookie_name_client_id: 'dummyname' });
+      var session = new ConstructorioID({ client_id_cookie_name: 'dummyname' });
       expect(session.client_id).to.equal('dummyid');
       expect(document.cookie).to.equal('dummyname=dummyid');
     });
 
-    it('should read the client id from the default cookie name', function () {
+    it('should set the client id if missing from the default storage location', function () {
       document.cookie = 'ConstructorioID_client_id=bummyid; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/';
       var session = new ConstructorioID();
       expect(session.client_id).to.equal('bummyid');
@@ -92,7 +92,7 @@ describe('ConstructorioID', function () {
     });
 
     it('should set the client id if missing', function () {
-      var session = new ConstructorioID({ cookie_name_client_id: 'missingname' });
+      var session = new ConstructorioID({ client_id_cookie_name: 'missingname' });
       expect(session.client_id).to.be.a.string;
       expect(session.client_id).to.match(/(\w|d|-){36}/);
     });
@@ -112,7 +112,7 @@ describe('ConstructorioID', function () {
     });
 
     it('should set the client id if missing and storage location is set to local', function () {
-      var session = new ConstructorioID({ cookie_name_client_id: 'missingname', client_id_storage_location: 'local' });
+      var session = new ConstructorioID({ client_id_cookie_name: 'missingname', client_id_storage_location: 'local' });
       expect(session.client_id).to.be.a.string;
       expect(session.client_id).to.match(/(\w|d|-){36}/);
     });

--- a/spec/001-initialization.js
+++ b/spec/001-initialization.js
@@ -14,7 +14,7 @@ describe('ConstructorioID', function () {
       'generate_client_id',
       'get_local_object',
       'set_local_object',
-      'get_session_id'
+      'generate_session_id'
     ];
     expect(actualKeys).to.eql(expectedKeys);
   });
@@ -23,7 +23,7 @@ describe('ConstructorioID', function () {
     var session = new ConstructorioID();
     expect(session.user_agent).to.be.null;
     expect(session.persist).to.be.true;
-    expect(session.cookie_name).to.equal('ConstructorioID_client_id');
+    expect(session.cookie_name_client_id).to.equal('ConstructorioID_client_id');
     expect(session.cookie_domain).to.be.null;
   });
 
@@ -34,7 +34,7 @@ describe('ConstructorioID', function () {
       user_agent: 'dummyagent',
       timeout: 1,
       persist: false,
-      cookie_name: 'dummyname',
+      cookie_name_client_id: 'dummyname',
       cookie_prefix_for_experiment: 'dummyprefix',
       cookie_domain: 'dummydomain'
     });
@@ -43,7 +43,7 @@ describe('ConstructorioID', function () {
     expect(session.user_agent).to.equal('dummyagent');
     expect(session.timeout).to.equal(1);
     expect(session.persist).to.be.false;
-    expect(session.cookie_name).to.equal('dummyname');
+    expect(session.cookie_name_client_id).to.equal('dummyname');
     expect(session.cookie_prefix_for_experiment).to.equal('dummyprefix');
     expect(session.cookie_domain).to.equal('dummydomain');
   });
@@ -65,7 +65,7 @@ describe('ConstructorioID', function () {
 
     it('should read the client id from a named cookie', function () {
       document.cookie = 'dummyname=dummyid; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/';
-      var session = new ConstructorioID({ cookie_name: 'dummyname' });
+      var session = new ConstructorioID({ cookie_name_client_id: 'dummyname' });
       expect(session.client_id).to.equal('dummyid');
       expect(document.cookie).to.equal('dummyname=dummyid');
     });
@@ -85,7 +85,7 @@ describe('ConstructorioID', function () {
     });
 
     it('should set the client id if missing', function () {
-      var session = new ConstructorioID({ cookie_name: 'missingname' });
+      var session = new ConstructorioID({ cookie_name_client_id: 'missingname' });
       expect(session.client_id).to.be.a.string;
       expect(session.client_id).to.match(/(\w|d|-){36}/);
     });

--- a/spec/001-initialization.js
+++ b/spec/001-initialization.js
@@ -24,6 +24,11 @@ describe('ConstructorioID', function () {
     expect(session.user_agent).to.be.null;
     expect(session.persist).to.be.true;
     expect(session.cookie_name_client_id).to.equal('ConstructorioID_client_id');
+    expect(session.cookie_name_session_id).to.equal('ConstructorioID_session_id');
+    expect(session.local_name_client_id).to.equal('_constructorio_search_client');
+    expect(session.local_name_session_id).to.equal('_constructorio_search_session');
+    expect(session.client_id_storage_location).to.equal('cookie');
+    expect(session.session_id_storage_location).to.equal('local');
     expect(session.cookie_domain).to.be.null;
   });
 
@@ -34,18 +39,28 @@ describe('ConstructorioID', function () {
       user_agent: 'dummyagent',
       timeout: 1,
       persist: false,
-      cookie_name_client_id: 'dummyname',
+      cookie_name_client_id: 'dummyclientname',
+      cookie_name_session_id: 'dummysessionname',
+      local_name_client_id: 'dummyclientnamelocal',
+      local_name_session_id: 'dummysessionnamelocal',
       cookie_prefix_for_experiment: 'dummyprefix',
-      cookie_domain: 'dummydomain'
+      cookie_domain: 'dummydomain',
+      client_id_storage_location: 'foo',
+      session_id_storage_location: 'bar'
     });
     expect(session.base_url).to.equal('dummyurl');
     expect(session.ip_address).to.equal('dummyip');
     expect(session.user_agent).to.equal('dummyagent');
     expect(session.timeout).to.equal(1);
     expect(session.persist).to.be.false;
-    expect(session.cookie_name_client_id).to.equal('dummyname');
+    expect(session.cookie_name_client_id).to.equal('dummyclientname');
+    expect(session.cookie_name_session_id).to.equal('dummysessionname');
+    expect(session.local_name_client_id).to.equal('dummyclientnamelocal');
+    expect(session.local_name_session_id).to.equal('dummysessionnamelocal');
     expect(session.cookie_prefix_for_experiment).to.equal('dummyprefix');
     expect(session.cookie_domain).to.equal('dummydomain');
+    expect(session.client_id_storage_location).to.equal('foo');
+    expect(session.session_id_storage_location).to.equal('bar');
   });
 
   describe('when used in browser', function () {

--- a/spec/001-initialization.js
+++ b/spec/001-initialization.js
@@ -97,7 +97,7 @@ describe('ConstructorioID', function () {
       expect(session.client_id).to.match(/(\w|d|-){36}/);
     });
 
-    it('should read the client id from local storage and storage location is set to local', function () {
+    it('should read the client id from local storage if storage location is set to local', function () {
       window.localStorage.setItem('dummyname', 'dummyid');
       var session = new ConstructorioID({ local_name_client_id: 'dummyname', client_id_storage_location: 'local' } );
       expect(session.client_id).to.equal('dummyid');
@@ -133,7 +133,7 @@ describe('ConstructorioID', function () {
       expect(session.session_id).to.equal(1);
     });
 
-    it('should read the session id from cookie and storage location is set to cookie', function () {
+    it('should read the session id from cookie if storage location is set to cookie', function () {
       document.cookie = `ConstructorioID_session_id={"sessionId":42,"lastTime":${Date.now()}}; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/`;
       var session = new ConstructorioID({ session_id_storage_location: 'cookie' });
       expect(session.session_id).to.be.a('number');
@@ -186,6 +186,12 @@ describe('ConstructorioID', function () {
 
     it('should set session_is_new to true if there is no local storage data', function () {
       var session = new ConstructorioID();
+      expect(session.session_is_new).to.be.a('boolean');
+      expect(session.session_is_new).to.equal(true);
+    });
+
+    it('should set session_is_new to true if there is no cookie data and storage location is set to cookie', function () {
+      var session = new ConstructorioID({ session_id_storage_location: 'cookie' });
       expect(session.session_is_new).to.be.a('boolean');
       expect(session.session_is_new).to.equal(true);
     });

--- a/spec/001-initialization.js
+++ b/spec/001-initialization.js
@@ -105,6 +105,26 @@ describe('ConstructorioID', function () {
       expect(session.client_id).to.match(/(\w|d|-){36}/);
     });
 
+    it('should read the client id from local storage and storage location is set to local', function () {
+      window.localStorage.setItem('dummyname', 'dummyid');
+      var session = new ConstructorioID({ local_name_client_id: 'dummyname', client_id_storage_location: 'local' } );
+      expect(session.client_id).to.equal('dummyid');
+      expect(window.localStorage.getItem('dummyname')).to.equal('dummyid');
+    });
+
+    it('should read the client id from the default local storage key and storage location is set to local', function () {
+      window.localStorage.setItem('_constructorio_search_client', 'bummyid');
+      var session = new ConstructorioID({ client_id_storage_location: 'local' });
+      expect(session.client_id).to.equal('bummyid');
+      expect(window.localStorage.getItem('_constructorio_search_client')).to.equal('bummyid');
+    });
+
+    it('should set the client id if missing and storage location is set to local', function () {
+      var session = new ConstructorioID({ cookie_name_client_id: 'missingname', client_id_storage_location: 'local' });
+      expect(session.client_id).to.be.a.string;
+      expect(session.client_id).to.match(/(\w|d|-){36}/);
+    });
+
     it('should read the session id from local storage data', function () {
       window.localStorage.setItem('_constructorio_search_session', JSON.stringify({
         sessionId: 42,

--- a/spec/005-storage.js
+++ b/spec/005-storage.js
@@ -51,7 +51,7 @@ describe('ConstructorioID', function () {
     });
   });
 
-  describe('get_session_id', function () {
+  describe('generate_session_id', function () {
     it('should return a session id from local storage if recent', function () {
       var now = Date.now();
       var session = new ConstructorioID();
@@ -62,7 +62,7 @@ describe('ConstructorioID', function () {
       }));
 
       var set_local_object = sinon.spy(ConstructorioID.prototype, 'set_local_object');
-      var session_id = session.get_session_id();
+      var session_id = session.generate_session_id();
       expect(session_id).to.be.a('number');
       expect(session_id).to.equal(42);
       expect(set_local_object.calledOnce).to.be.true;
@@ -83,7 +83,7 @@ describe('ConstructorioID', function () {
       }));
 
       var set_local_object = sinon.spy(ConstructorioID.prototype, 'set_local_object');
-      var session_id = session.get_session_id();
+      var session_id = session.generate_session_id();
       expect(session_id).to.be.a('number');
       expect(session_id).to.equal(43);
       expect(set_local_object.calledOnce).to.be.true;
@@ -100,7 +100,7 @@ describe('ConstructorioID', function () {
       window.localStorage.clear();
 
       var set_local_object = sinon.spy(ConstructorioID.prototype, 'set_local_object');
-      var session_id = session.get_session_id();
+      var session_id = session.generate_session_id();
       expect(session_id).to.be.a('number');
       expect(session_id).to.equal(1);
       expect(set_local_object.calledOnce).to.be.true;

--- a/spec/005-storage.js
+++ b/spec/005-storage.js
@@ -43,12 +43,6 @@ describe('ConstructorioID', function () {
       expect(window.localStorage.adventuretime).to.be.a.string;
       expect(JSON.parse(window.localStorage.adventuretime)).to.deep.equal({ marceline: true });
     });
-
-    it('should not set a non-object', function () {
-      var session = new ConstructorioID();
-      session.set_local_object('adventuretime', 'We\'re going to very distant lands.');
-      expect(window.localStorage.adventuretime).to.be.undefined;
-    });
   });
 
   describe('generate_session_id', function () {

--- a/spec/005-storage.js
+++ b/spec/005-storage.js
@@ -28,11 +28,11 @@ describe('ConstructorioID', function () {
       expect(adventuretime.jake).to.be.true;
     });
 
-    it('should not return a non-object', function () {
+    it('should not return a local string', function () {
       window.localStorage.setItem('adventuretime', 'Come on grab your friends');
       var session = new ConstructorioID();
       var adventuretime = session.get_local_object('adventuretime');
-      expect(adventuretime).to.be.undefined;
+      expect(adventuretime).to.equal('Come on grab your friends');
     });
   });
 
@@ -67,7 +67,7 @@ describe('ConstructorioID', function () {
       set_local_object.restore();
     });
 
-    it('should return a session id in cookie if recent and storage location is set to cookie', function () {
+    it('should return the same session id from cookie if recent and the storage location is set to cookie', function () {
       var now = Date.now();
       var session = new ConstructorioID({ session_id_storage_location: 'cookie' });
       document.cookie = `ConstructorioID_session_id={"sessionId":42,"lastTime":${now}}; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/`;

--- a/spec/006-cookies.js
+++ b/spec/006-cookies.js
@@ -43,7 +43,7 @@ describe('ConstructorioID', function () {
     it('should update a matching cookie', function () {
       document.cookie = 'dummyname=dummyid; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/';
       document.cookie = 'ConstructorioAB_veggie=turnips; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/';
-      var session = new ConstructorioID({ cookie_name: 'dummyname' });
+      var session = new ConstructorioID({ cookie_name_client_id: 'dummyname' });
       session.update_cookie('ConstructorioID_veggie');
       expect(document.cookie).to.equal('dummyname=dummyid; ConstructorioID_veggie=turnips');
     });
@@ -51,7 +51,7 @@ describe('ConstructorioID', function () {
     it('should skip a non matching cookie', function () {
       document.cookie = 'dummyname=dummyid; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/';
       document.cookie = 'ConstructorioBC_veggie=turnips; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/';
-      var session = new ConstructorioID({ cookie_name: 'dummyname' });
+      var session = new ConstructorioID({ cookie_name_client_id: 'dummyname' });
       session.update_cookie('ConstructorioID_veggie');
       expect(document.cookie).to.equal('dummyname=dummyid; ConstructorioBC_veggie=turnips');
     });
@@ -61,7 +61,7 @@ describe('ConstructorioID', function () {
     it('should remove a matching cookie', function () {
       document.cookie = 'dummyname=dummyid; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/';
       document.cookie = 'deleteme=now; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/';
-      var session = new ConstructorioID({ cookie_name: 'dummyname' });
+      var session = new ConstructorioID({ cookie_name_client_id: 'dummyname' });
       session.delete_cookie('deleteme');
       expect(document.cookie).to.equal('dummyname=dummyid');
     });
@@ -69,7 +69,7 @@ describe('ConstructorioID', function () {
     it('should skip a non-matching cookie', function () {
       document.cookie = 'dummyname=dummyid; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/';
       document.cookie = 'skipme=now; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/';
-      var session = new ConstructorioID({ cookie_name: 'dummyname' });
+      var session = new ConstructorioID({ cookie_name_client_id: 'dummyname' });
       session.delete_cookie('deleteme');
       expect(document.cookie).to.equal('dummyname=dummyid; skipme=now');
     });
@@ -77,7 +77,7 @@ describe('ConstructorioID', function () {
 
   describe('generate_client_id', function () {
     it('should return a client id and set the cookie', function () {
-      var session = new ConstructorioID({ cookie_name: 'monster' });
+      var session = new ConstructorioID({ cookie_name_client_id: 'monster' });
       var client_id = session.generate_client_id();
       expect(session.get_cookie('monster')).to.equal(client_id);
       expect(client_id).to.be.a.string;

--- a/spec/006-cookies.js
+++ b/spec/006-cookies.js
@@ -43,7 +43,7 @@ describe('ConstructorioID', function () {
     it('should remove a matching cookie', function () {
       document.cookie = 'dummyname=dummyid; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/';
       document.cookie = 'deleteme=now; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/';
-      var session = new ConstructorioID({ cookie_name_client_id: 'dummyname' });
+      var session = new ConstructorioID({ client_id_cookie_name: 'dummyname' });
       session.delete_cookie('deleteme');
       expect(document.cookie).to.equal('dummyname=dummyid');
     });
@@ -51,7 +51,7 @@ describe('ConstructorioID', function () {
     it('should skip a non-matching cookie', function () {
       document.cookie = 'dummyname=dummyid; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/';
       document.cookie = 'skipme=now; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/';
-      var session = new ConstructorioID({ cookie_name_client_id: 'dummyname' });
+      var session = new ConstructorioID({ client_id_cookie_name: 'dummyname' });
       session.delete_cookie('deleteme');
       expect(document.cookie).to.equal('dummyname=dummyid; skipme=now');
     });
@@ -59,7 +59,7 @@ describe('ConstructorioID', function () {
 
   describe('generate_client_id', function () {
     it('should return a client id and set the cookie', function () {
-      var session = new ConstructorioID({ cookie_name_client_id: 'monster' });
+      var session = new ConstructorioID({ client_id_cookie_name: 'monster' });
       var client_id = session.generate_client_id();
       expect(session.get_cookie('monster')).to.equal(client_id);
       expect(client_id).to.be.a.string;

--- a/spec/006-cookies.js
+++ b/spec/006-cookies.js
@@ -65,5 +65,13 @@ describe('ConstructorioID', function () {
       expect(client_id).to.be.a.string;
       expect(client_id).to.match(/(\w|d|-){36}/);
     });
+
+    it('should return a client id and set local storage value if storage location is set to local', function () {
+      var session = new ConstructorioID({ local_name_client_id: 'monster', client_id_storage_location: 'local' });
+      var client_id = session.generate_client_id();
+      expect(session.get_local_object('monster')).to.equal(client_id);
+      expect(client_id).to.be.a.string;
+      expect(client_id).to.match(/(\w|d|-){36}/);
+    });
   });
 });

--- a/spec/006-cookies.js
+++ b/spec/006-cookies.js
@@ -39,24 +39,6 @@ describe('ConstructorioID', function () {
     });
   });
 
-  describe('update_cookie', function () {
-    it('should update a matching cookie', function () {
-      document.cookie = 'dummyname=dummyid; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/';
-      document.cookie = 'ConstructorioAB_veggie=turnips; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/';
-      var session = new ConstructorioID({ cookie_name_client_id: 'dummyname' });
-      session.update_cookie('ConstructorioID_veggie');
-      expect(document.cookie).to.equal('dummyname=dummyid; ConstructorioID_veggie=turnips');
-    });
-
-    it('should skip a non matching cookie', function () {
-      document.cookie = 'dummyname=dummyid; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/';
-      document.cookie = 'ConstructorioBC_veggie=turnips; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/';
-      var session = new ConstructorioID({ cookie_name_client_id: 'dummyname' });
-      session.update_cookie('ConstructorioID_veggie');
-      expect(document.cookie).to.equal('dummyname=dummyid; ConstructorioBC_veggie=turnips');
-    });
-  });
-
   describe('delete_cookie', function () {
     it('should remove a matching cookie', function () {
       document.cookie = 'dummyname=dummyid; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/';

--- a/src/constructorio-id.js
+++ b/src/constructorio-id.js
@@ -16,7 +16,7 @@
       on_node: typeof window === 'undefined',
       session_is_new: null,
       client_id_storage_location: 'cookie',
-      session_id_storage_location: 'local',
+      session_id_storage_location: 'local'
     };
 
     Object.assign(this, defaults, options);

--- a/src/constructorio-id.js
+++ b/src/constructorio-id.js
@@ -7,7 +7,7 @@
     var defaults = {
       user_agent: null,
       persist: true,
-      cookie_name: 'ConstructorioID_client_id',
+      cookie_name_client_id: 'ConstructorioID_client_id',
       cookie_domain: null,
       cookie_days_to_live: 365,
       on_node: typeof window === 'undefined',
@@ -18,8 +18,8 @@
 
     if (!this.client_id) {
       if (!this.on_node && this.persist) {
-        this.update_cookie(this.cookie_name);
-        var persisted_id = this.get_cookie(this.cookie_name);
+        this.update_cookie(this.cookie_name_client_id);
+        var persisted_id = this.get_cookie(this.cookie_name_client_id);
         this.client_id = persisted_id ? persisted_id : this.generate_client_id();
       } else {
         this.client_id = this.generate_client_id();
@@ -28,7 +28,7 @@
 
     if (!this.session_id) {
       if (!this.on_node && this.persist) {
-        this.session_id = this.get_session_id();
+        this.session_id = this.generate_session_id();
       } else {
         this.session_id = 1;
       }
@@ -92,7 +92,9 @@
       var v = c === 'x' ? r : (r & 0x3 | 0x8);
       return v.toString(16);
     });
-    this.set_cookie(this.cookie_name, client_id);
+
+    this.set_cookie(this.cookie_name_client_id, client_id);
+
     return client_id;
   };
 
@@ -120,7 +122,7 @@
     }
   };
 
-  ConstructorioID.prototype.get_session_id = function () {
+  ConstructorioID.prototype.generate_session_id = function () {
     var now = Date.now();
     var thirtyMinutes = 1000 * 60 * 30;
     var sessionKey = '_constructorio_search_session';

--- a/src/constructorio-id.js
+++ b/src/constructorio-id.js
@@ -23,8 +23,20 @@
 
     if (!this.client_id) {
       if (!this.on_node && this.persist) {
-        this.update_cookie(this.cookie_name_client_id);
-        var persisted_id = this.get_cookie(this.cookie_name_client_id);
+        var persisted_id;
+
+        if (this.client_id_storage_location === 'cookie') {
+          this.update_cookie(this.cookie_name_client_id);
+
+          persisted_id = this.get_cookie(this.cookie_name_client_id);
+        }
+
+        if (this.client_id_storage_location === 'local') {
+          this.update_cookie(this.cookie_name_client_id);
+
+          persisted_id = this.get_local_object(this.local_name_client_id);
+        }
+
         this.client_id = persisted_id ? persisted_id : this.generate_client_id();
       } else {
         this.client_id = this.generate_client_id();
@@ -136,7 +148,22 @@
   ConstructorioID.prototype.generate_session_id = function () {
     var now = Date.now();
     var thirtyMinutes = 1000 * 60 * 30;
-    var sessionData = this.get_local_object(this.local_name_session_id);
+    var sessionData;
+
+    if (this.session_id_storage_location === 'local') {
+      sessionData = this.get_local_object(this.local_name_session_id);
+    }
+
+    if (this.session_id_storage_location === 'cookie') {
+      sessionData = this.get_cookie(this.local_name_session_id);
+
+      try {
+        sessionData = JSON.parse(sessionData);
+      } catch (e) {
+        return false;
+      }
+    }
+
     var sessionId = 1;
 
     if (sessionData) {

--- a/src/constructorio-id.js
+++ b/src/constructorio-id.js
@@ -99,7 +99,7 @@
       this.set_cookie(this.cookie_name_client_id, client_id);
     }
 
-    if (this.client_id_storage_location === 'session') {
+    if (this.client_id_storage_location === 'local') {
       this.set_local_object(this.local_name_client_id, client_id);
     }
 
@@ -124,13 +124,24 @@
     return data;
   };
 
-  ConstructorioID.prototype.set_local_object = function (key, obj) {
+  ConstructorioID.prototype.set_local_object = function (key, data) {
     var localStorage = window && window.localStorage;
-    if (localStorage && typeof key  === 'string' && typeof obj === 'object') {
-      try {
-        localStorage.setItem(key, JSON.stringify(obj));
-      } catch (e) {
-        // fail silently
+
+    if (localStorage && typeof key === 'string') {
+      if (typeof data === 'object') {
+        try {
+          localStorage.setItem(key, JSON.stringify(data));
+        } catch (e) {
+          // fail silently
+        }
+      }
+
+      if (typeof data === 'string') {
+        try {
+          localStorage.setItem(key, data);
+        } catch (e) {
+          // fail silently
+        }
       }
     }
   };

--- a/src/constructorio-id.js
+++ b/src/constructorio-id.js
@@ -7,8 +7,8 @@
     var defaults = {
       user_agent: null,
       persist: true,
-      cookie_name_client_id: 'ConstructorioID_client_id',
-      cookie_name_session_id: 'ConstructorioID_session_id',
+      client_id_cookie_name: 'ConstructorioID_client_id',
+      session_id_cookie_name: 'ConstructorioID_session_id',
       cookie_domain: null,
       cookie_days_to_live: 365,
       local_name_client_id: '_constructorio_search_client',
@@ -26,7 +26,7 @@
         var persisted_id;
 
         if (this.client_id_storage_location === 'cookie') {
-          persisted_id = this.get_cookie(this.cookie_name_client_id);
+          persisted_id = this.get_cookie(this.client_id_cookie_name);
         }
 
         if (this.client_id_storage_location === 'local') {
@@ -96,7 +96,7 @@
     });
 
     if (this.client_id_storage_location === 'cookie') {
-      this.set_cookie(this.cookie_name_client_id, client_id);
+      this.set_cookie(this.client_id_cookie_name, client_id);
     }
 
     if (this.client_id_storage_location === 'local') {
@@ -151,7 +151,7 @@
     }
 
     if (this.session_id_storage_location === 'cookie') {
-      sessionData = this.get_cookie(this.cookie_name_session_id);
+      sessionData = this.get_cookie(this.session_id_cookie_name);
 
       try {
         sessionData = JSON.parse(sessionData);
@@ -181,7 +181,7 @@
     }
 
     if (this.session_id_storage_location === 'cookie') {
-      this.set_cookie(this.cookie_name_session_id, JSON.stringify({
+      this.set_cookie(this.session_id_cookie_name, JSON.stringify({
         sessionId: sessionId,
         lastTime: now
       }));

--- a/src/constructorio-id.js
+++ b/src/constructorio-id.js
@@ -32,8 +32,6 @@
         }
 
         if (this.client_id_storage_location === 'local') {
-          this.update_cookie(this.cookie_name_client_id);
-
           persisted_id = this.get_local_object(this.local_name_client_id);
         }
 
@@ -128,7 +126,12 @@
       try {
         data = JSON.parse(localStorage.getItem(key));
       } catch (e) {
-        // fail silently
+        if (
+          (key === this.local_name_client_id && this.client_id_storage_location === 'local')
+          || (key === this.local_name_session_id && this.session_id_storage_location === 'local')
+        ) {
+          data = localStorage.getItem(key);
+        }
       }
     }
     return data;

--- a/src/constructorio-id.js
+++ b/src/constructorio-id.js
@@ -26,8 +26,6 @@
         var persisted_id;
 
         if (this.client_id_storage_location === 'cookie') {
-          this.update_cookie(this.cookie_name_client_id);
-
           persisted_id = this.get_cookie(this.cookie_name_client_id);
         }
 
@@ -84,17 +82,6 @@
       }
     }
     return undefined; // eslint-disable-line
-  };
-
-  ConstructorioID.prototype.update_cookie = function (name) {
-    if (name.match(/^ConstructorioID_/)) {
-      var oldName = name.replace(/^ConstructorioID_/, 'ConstructorioAB_');
-      var value = this.get_cookie(oldName);
-      if (value) {
-        this.set_cookie(name, value);
-        this.delete_cookie(oldName);
-      }
-    }
   };
 
   ConstructorioID.prototype.delete_cookie = function (name) {

--- a/src/constructorio-id.js
+++ b/src/constructorio-id.js
@@ -8,10 +8,15 @@
       user_agent: null,
       persist: true,
       cookie_name_client_id: 'ConstructorioID_client_id',
+      cookie_name_session_id: 'ConstructorioID_session_id',
       cookie_domain: null,
       cookie_days_to_live: 365,
+      local_name_client_id: '_constructorio_search_client',
+      local_name_session_id: '_constructorio_search_session',
       on_node: typeof window === 'undefined',
-      session_is_new: null
+      session_is_new: null,
+      client_id_storage_location: 'cookie',
+      session_id_storage_location: 'local',
     };
 
     Object.assign(this, defaults, options);
@@ -93,7 +98,9 @@
       return v.toString(16);
     });
 
-    this.set_cookie(this.cookie_name_client_id, client_id);
+    if (this.client_id_storage_location === 'cookie') {
+      this.set_cookie(this.cookie_name_client_id, client_id);
+    }
 
     return client_id;
   };
@@ -125,8 +132,7 @@
   ConstructorioID.prototype.generate_session_id = function () {
     var now = Date.now();
     var thirtyMinutes = 1000 * 60 * 30;
-    var sessionKey = '_constructorio_search_session';
-    var sessionData = this.get_local_object(sessionKey);
+    var sessionData = this.get_local_object(this.local_name_session_id);
     var sessionId = 1;
 
     if (sessionData) {
@@ -139,10 +145,13 @@
 
     this.session_id = sessionId;
     this.session_is_new = sessionData && sessionData.sessionId === sessionId ? false : true;
-    this.set_local_object(sessionKey, {
-      sessionId: sessionId,
-      lastTime: now
-    });
+
+    if (this.session_id_storage_location === 'local') {
+      this.set_local_object(this.local_name_session_id, {
+        sessionId: sessionId,
+        lastTime: now
+      });
+    }
 
     return sessionId;
   };

--- a/src/constructorio-id.js
+++ b/src/constructorio-id.js
@@ -113,12 +113,7 @@
       try {
         data = JSON.parse(localStorage.getItem(key));
       } catch (e) {
-        if (
-          (key === this.local_name_client_id && this.client_id_storage_location === 'local')
-          || (key === this.local_name_session_id && this.session_id_storage_location === 'local')
-        ) {
-          data = localStorage.getItem(key);
-        }
+        data = localStorage.getItem(key);
       }
     }
     return data;

--- a/src/constructorio-id.js
+++ b/src/constructorio-id.js
@@ -102,6 +102,10 @@
       this.set_cookie(this.cookie_name_client_id, client_id);
     }
 
+    if (this.client_id_storage_location === 'session') {
+      this.set_local_object(this.local_name_client_id, client_id);
+    }
+
     return client_id;
   };
 
@@ -151,6 +155,13 @@
         sessionId: sessionId,
         lastTime: now
       });
+    }
+
+    if (this.session_id_storage_location === 'cookie') {
+      this.set_cookie(this.cookie_name_session_id, JSON.stringify({
+        sessionId: sessionId,
+        lastTime: now
+      }));
     }
 
     return sessionId;

--- a/src/constructorio-id.js
+++ b/src/constructorio-id.js
@@ -145,12 +145,12 @@
     }
 
     if (this.session_id_storage_location === 'cookie') {
-      sessionData = this.get_cookie(this.local_name_session_id);
+      sessionData = this.get_cookie(this.cookie_name_session_id);
 
       try {
         sessionData = JSON.parse(sessionData);
       } catch (e) {
-        return false;
+        // fail silently
       }
     }
 


### PR DESCRIPTION
- Remove `update_cookie` method
- More consistent method naming
- Add options to set naming for both client and session names (keys)
- Allow specification of where both client and session id's should be stored individually
- Backwards compatible
- 8 tests added
- Lint passes

---

**Manual testing:**
- Verified there is no direct access to cookie or local storage from our clients. There are a few spec files that make modifications, but nothing critical.
- Referenced local version of identity module and tested changing storage locations + setting different cookie + local storage key names

<img width="444" alt="Screen Shot 2020-06-06 at 6 12 22 PM" src="https://user-images.githubusercontent.com/4909263/83957046-59129a80-a821-11ea-820f-b6732002bf7f.png">

We should be good to go here! No change necessary on any of our clients, but we should change any client planning to use a backend integration to use cookies for both values rather than local storage.