### PR TITLE
Store session_id as pipe separated value, rather than in JSON object.

### DIFF
--- a/spec/001-initialization.js
+++ b/spec/001-initialization.js
@@ -11,8 +11,8 @@ describe('ConstructorioID', function () {
       'get_cookie',
       'delete_cookie',
       'generate_client_id',
-      'get_local_object',
-      'set_local_object',
+      'get_local_value',
+      'set_local_value',
       'generate_session_id'
     ];
     expect(actualKeys).to.eql(expectedKeys);
@@ -123,7 +123,7 @@ describe('ConstructorioID', function () {
       window.localStorage.setItem('_constructorio_search_session', sessionId + '|' + lastTime);
       var session = new ConstructorioID();
       expect(session.session_id).to.be.a('number');
-      expect(session.session_id).to.equal(42);
+      expect(session.session_id).to.equal(sessionId);
     });
 
     it('should read the session id from local storage data if data is being stored in legacy (JSON) format', function () {
@@ -182,7 +182,7 @@ describe('ConstructorioID', function () {
 
       window.localStorage.setItem('_constructorio_search_session', sessionId + '|' + lastTime);
       var session = new ConstructorioID();
-      expect(session.session_id).to.equal(42);
+      expect(session.session_id).to.equal(sessionId);
       expect(session.session_is_new).to.be.a('boolean');
       expect(session.session_is_new).to.equal(false);
     });
@@ -202,7 +202,7 @@ describe('ConstructorioID', function () {
       const lastTime = Date.now();
       document.cookie = `ConstructorioID_session_id=${sessionId}|${lastTime}; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/`;
       var session = new ConstructorioID({ session_id_storage_location: 'cookie' });
-      expect(session.session_id).to.equal(42);
+      expect(session.session_id).to.equal(sessionId);
       expect(session.session_is_new).to.be.a('boolean');
       expect(session.session_is_new).to.equal(false);
     });

--- a/spec/001-initialization.js
+++ b/spec/001-initialization.js
@@ -118,10 +118,9 @@ describe('ConstructorioID', function () {
     });
 
     it('should read the session id from local storage data', function () {
-      window.localStorage.setItem('_constructorio_search_session', JSON.stringify({
-        sessionId: 42,
-        lastTime: Date.now()
-      }));
+      const sessionId = 42;
+      const lastTime = Date.now();
+      window.localStorage.setItem('_constructorio_search_session', sessionId + '|' + lastTime);
       var session = new ConstructorioID();
       expect(session.session_id).to.be.a('number');
       expect(session.session_id).to.equal(42);
@@ -134,10 +133,12 @@ describe('ConstructorioID', function () {
     });
 
     it('should read the session id from cookie if storage location is set to cookie', function () {
-      document.cookie = `ConstructorioID_session_id={"sessionId":42,"lastTime":${Date.now()}}; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/`;
+      const sessionId = 42;
+      const lastTime = Date.now();
+      document.cookie = `ConstructorioID_session_id=${sessionId}|${lastTime}; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/`;
       var session = new ConstructorioID({ session_id_storage_location: 'cookie' });
       expect(session.session_id).to.be.a('number');
-      expect(session.session_id).to.equal(42);
+      expect(session.session_id).to.equal(sessionId);
     });
 
     it('should set the session id to 1 if there is no cookie and storage location is set to cookie', function () {
@@ -147,10 +148,10 @@ describe('ConstructorioID', function () {
     });
 
     it('should set session_is_new to false if the session is not new', function () {
-      window.localStorage.setItem('_constructorio_search_session', JSON.stringify({
-        sessionId: 42,
-        lastTime: Date.now()
-      }));
+      const sessionId = 42;
+      const lastTime = Date.now();
+
+      window.localStorage.setItem('_constructorio_search_session', sessionId + '|' + lastTime);
       var session = new ConstructorioID();
       expect(session.session_id).to.equal(42);
       expect(session.session_is_new).to.be.a('boolean');
@@ -158,10 +159,9 @@ describe('ConstructorioID', function () {
     });
 
     it('should set session_is_new to true if the session is new', function () {
-      window.localStorage.setItem('_constructorio_search_session', JSON.stringify({
-        sessionId: 42,
-        lastTime: Date.now() - 1000 * 60 * 60 * 24 * 60
-      }));
+      const sessionId = 42;
+      const lastTime = Date.now() - 1000 * 60 * 60 * 24 * 60;
+      window.localStorage.setItem('_constructorio_search_session', sessionId + '|' + lastTime);
       var session = new ConstructorioID();
       expect(session.session_id).to.equal(43);
       expect(session.session_is_new).to.be.a('boolean');
@@ -169,7 +169,9 @@ describe('ConstructorioID', function () {
     });
 
     it('should set session_is_new to false if the session is not new and storage location is set to cookie', function () {
-      document.cookie = `ConstructorioID_session_id={"sessionId":42,"lastTime":${Date.now()}}; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/`;
+      const sessionId = 42;
+      const lastTime = Date.now();
+      document.cookie = `ConstructorioID_session_id=${sessionId}|${lastTime}; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/`;
       var session = new ConstructorioID({ session_id_storage_location: 'cookie' });
       expect(session.session_id).to.equal(42);
       expect(session.session_is_new).to.be.a('boolean');
@@ -177,7 +179,9 @@ describe('ConstructorioID', function () {
     });
 
     it('should set session_is_new to true if the session is new and storage location is set to cookie', function () {
-      document.cookie = `ConstructorioID_session_id={"sessionId":42,"lastTime":${Date.now() - 1000 * 60 * 60 * 24 * 60}}; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/`;
+      const sessionId = 42;
+      const lastTime = Date.now() - 1000 * 60 * 60 * 24 * 60;
+      document.cookie = `ConstructorioID_session_id=${sessionId}|${lastTime}; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/`;
       var session = new ConstructorioID({ session_id_storage_location: 'cookie' });
       expect(session.session_id).to.equal(43);
       expect(session.session_is_new).to.be.a('boolean');

--- a/spec/001-initialization.js
+++ b/spec/001-initialization.js
@@ -126,6 +126,22 @@ describe('ConstructorioID', function () {
       expect(session.session_id).to.equal(42);
     });
 
+    it('should read the session id from local storage data if data is being stored in legacy (JSON) format', function () {
+      const sessionId = 42;
+      const lastTime = Date.now();
+      window.localStorage.setItem('_constructorio_search_session', JSON.stringify({
+        sessionId,
+        lastTime
+      }));
+      var session = new ConstructorioID();
+      expect(session.session_id).to.be.a('number');
+      expect(session.session_id).to.equal(sessionId);
+      var newSessionData = window.localStorage.getItem('_constructorio_search_session');
+      var newSessionDataSplit = newSessionData.split('|');
+      expect(parseInt(newSessionDataSplit[0], 10)).to.equal(sessionId);
+      expect(parseInt(newSessionDataSplit[1], 10)).to.be.at.least(lastTime);
+    });
+
     it('should set the session id to 1 if there is no local storage data', function () {
       var session = new ConstructorioID();
       expect(session.session_id).to.be.a('number');
@@ -139,6 +155,19 @@ describe('ConstructorioID', function () {
       var session = new ConstructorioID({ session_id_storage_location: 'cookie' });
       expect(session.session_id).to.be.a('number');
       expect(session.session_id).to.equal(sessionId);
+    });
+
+    it('should read the session id from cookie if storage location is set to cookie if data is being stored in legacy (JSON) format', function () {
+      const sessionId = 42;
+      const lastTime = Date.now();
+      document.cookie = `ConstructorioID_session_id=${JSON.stringify({ sessionId, lastTime })}; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/`;
+      var session = new ConstructorioID({ session_id_storage_location: 'cookie' });
+      expect(session.session_id).to.be.a('number');
+      expect(session.session_id).to.equal(sessionId);
+      var newSessionDataMatch = document.cookie.match(/ConstructorioID_session_id=(.*);/);
+      var newSessionDataSplit = newSessionDataMatch && newSessionDataMatch[1].split('|');
+      expect(parseInt(newSessionDataSplit[0], 10)).to.equal(sessionId);
+      expect(parseInt(newSessionDataSplit[1], 10)).to.be.at.least(lastTime);
     });
 
     it('should set the session id to 1 if there is no cookie and storage location is set to cookie', function () {

--- a/spec/005-storage.js
+++ b/spec/005-storage.js
@@ -19,19 +19,19 @@ describe('ConstructorioID', function () {
     delete global.document;
   });
 
-  describe('get_local_object', function () {
+  describe('get_local_value', function () {
     it('should not return a local string', function () {
       window.localStorage.setItem('adventuretime', 'Come on grab your friends');
       var session = new ConstructorioID();
-      var adventuretime = session.get_local_object('adventuretime');
+      var adventuretime = session.get_local_value('adventuretime');
       expect(adventuretime).to.equal('Come on grab your friends');
     });
   });
 
-  describe('set_local_object', function () {
+  describe('set_local_value', function () {
     it('should set a local string', function () {
       var session = new ConstructorioID();
-      session.set_local_object('adventuretime', 'bmo');
+      session.set_local_value('adventuretime', 'bmo');
       expect(window.localStorage.adventuretime).to.be.a.string;
       expect(window.localStorage.adventuretime).to.deep.equal('bmo');
     });
@@ -46,17 +46,17 @@ describe('ConstructorioID', function () {
       window.localStorage.clear();
       window.localStorage.setItem('_constructorio_search_session', sessionId + '|' + lastTime);
 
-      var set_local_object = sinon.spy(ConstructorioID.prototype, 'set_local_object');
+      var set_local_value = sinon.spy(ConstructorioID.prototype, 'set_local_value');
       var session_id = session.generate_session_id();
       expect(session_id).to.be.a('number');
       expect(session_id).to.equal(42);
-      expect(set_local_object.calledOnce).to.be.true;
-      expect(set_local_object.calledWith('_constructorio_search_session')).to.be.true;
-      var callArgsSplit = set_local_object.getCall(0).args[1].split('|');
+      expect(set_local_value.calledOnce).to.be.true;
+      expect(set_local_value.calledWith('_constructorio_search_session')).to.be.true;
+      var callArgsSplit = set_local_value.getCall(0).args[1].split('|');
       expect(parseInt(callArgsSplit[0], 10)).to.equal(42);
       expect(parseInt(callArgsSplit[1], 10)).to.be.at.least(now);
 
-      set_local_object.restore();
+      set_local_value.restore();
     });
 
     it('should return the same session id from cookie if recent and the storage location is set to cookie', function () {
@@ -86,17 +86,17 @@ describe('ConstructorioID', function () {
       window.localStorage.clear();
       window.localStorage.setItem('_constructorio_search_session', sessionId + '|' + lastTime);
 
-      var set_local_object = sinon.spy(ConstructorioID.prototype, 'set_local_object');
+      var set_local_value = sinon.spy(ConstructorioID.prototype, 'set_local_value');
       var session_id = session.generate_session_id();
       expect(session_id).to.be.a('number');
       expect(session_id).to.equal(43);
-      expect(set_local_object.calledOnce).to.be.true;
-      expect(set_local_object.calledWith('_constructorio_search_session')).to.be.true;
-      var callArgsSplit = set_local_object.getCall(0).args[1].split('|');
+      expect(set_local_value.calledOnce).to.be.true;
+      expect(set_local_value.calledWith('_constructorio_search_session')).to.be.true;
+      var callArgsSplit = set_local_value.getCall(0).args[1].split('|');
       expect(parseInt(callArgsSplit[0], 10)).to.equal(43);
       expect(parseInt(callArgsSplit[1], 10)).to.be.at.least(now);
 
-      set_local_object.restore();
+      set_local_value.restore();
     });
 
     it('should increment session id from cookie if older than thirty minutes and storage location is set to cookie', function () {
@@ -124,16 +124,16 @@ describe('ConstructorioID', function () {
       var session = new ConstructorioID();
       window.localStorage.clear();
 
-      var set_local_object = sinon.spy(ConstructorioID.prototype, 'set_local_object');
+      var set_local_value = sinon.spy(ConstructorioID.prototype, 'set_local_value');
       var session_id = session.generate_session_id();
       expect(session_id).to.be.a('number');
       expect(session_id).to.equal(1);
-      expect(set_local_object.calledOnce).to.be.true;
-      expect(set_local_object.calledWith('_constructorio_search_session')).to.be.true;
-      var callArgsSplit = set_local_object.getCall(0).args[1].split('|');
+      expect(set_local_value.calledOnce).to.be.true;
+      expect(set_local_value.calledWith('_constructorio_search_session')).to.be.true;
+      var callArgsSplit = set_local_value.getCall(0).args[1].split('|');
       expect(parseInt(callArgsSplit[0], 10)).to.equal(1);
       expect(parseInt(callArgsSplit[1], 10)).to.be.at.least(now);
-      set_local_object.restore();
+      set_local_value.restore();
     });
 
     it('should set a session id in cookie if missing and storage location is set to cookie', function () {

--- a/spec/006-cookies.js
+++ b/spec/006-cookies.js
@@ -69,7 +69,7 @@ describe('ConstructorioID', function () {
     it('should return a client id and set local storage value if storage location is set to local', function () {
       var session = new ConstructorioID({ local_name_client_id: 'monster', client_id_storage_location: 'local' });
       var client_id = session.generate_client_id();
-      expect(session.get_local_object('monster')).to.equal(client_id);
+      expect(session.get_local_value('monster')).to.equal(client_id);
       expect(client_id).to.be.a.string;
       expect(client_id).to.match(/(\w|d|-){36}/);
     });

--- a/src/constructorio-id.js
+++ b/src/constructorio-id.js
@@ -30,7 +30,7 @@
         }
 
         if (this.client_id_storage_location === 'local') {
-          persisted_id = this.get_local_object(this.local_name_client_id);
+          persisted_id = this.get_local_value(this.local_name_client_id);
         }
 
         this.client_id = persisted_id ? persisted_id : this.generate_client_id();
@@ -100,13 +100,13 @@
     }
 
     if (this.client_id_storage_location === 'local') {
-      this.set_local_object(this.local_name_client_id, client_id);
+      this.set_local_value(this.local_name_client_id, client_id);
     }
 
     return client_id;
   };
 
-  ConstructorioID.prototype.get_local_object = function (key) {
+  ConstructorioID.prototype.get_local_value = function (key) {
     var data;
     var localStorage = window && window.localStorage;
 
@@ -121,7 +121,7 @@
     return data;
   };
 
-  ConstructorioID.prototype.set_local_object = function (key, data) {
+  ConstructorioID.prototype.set_local_value = function (key, data) {
     var localStorage = window && window.localStorage;
 
     if (localStorage && typeof key === 'string' && typeof data === 'string') {
@@ -142,7 +142,7 @@
     var sessionDataJSON;
 
     if (this.session_id_storage_location === 'local') {
-      sessionDataString = this.get_local_object(this.local_name_session_id);
+      sessionDataString = this.get_local_value(this.local_name_session_id);
     }
 
     if (this.session_id_storage_location === 'cookie') {
@@ -183,7 +183,7 @@
     this.session_is_new = sessionData && sessionData.sessionId === sessionId ? false : true;
 
     if (this.session_id_storage_location === 'local') {
-      this.set_local_object(this.local_name_session_id, sessionId + '|' + now);
+      this.set_local_value(this.local_name_session_id, sessionId + '|' + now);
     }
 
     if (this.session_id_storage_location === 'cookie') {

--- a/src/constructorio-id.js
+++ b/src/constructorio-id.js
@@ -139,6 +139,7 @@
     var sessionDataString;
     var sessionDataSplit;
     var sessionData;
+    var sessionDataJSON;
 
     if (this.session_id_storage_location === 'local') {
       sessionDataString = this.get_local_object(this.local_name_session_id);
@@ -149,11 +150,23 @@
     }
 
     if (sessionDataString) {
-      sessionDataSplit = sessionDataString && sessionDataString.split('|');
-      sessionData = {
-        sessionId: parseInt(sessionDataSplit && sessionDataSplit[0], 10),
-        lastTime: parseInt(sessionDataSplit && sessionDataSplit[1], 10)
-      };
+      // Ensure backwards compatibility with legacy data structure (JSON)
+      try {
+        sessionDataJSON = JSON.parse(sessionDataString);
+      } catch (e) {
+        // fail silently
+      }
+
+      // Ensure backwards compatibility with legacy data structure (JSON)
+      if (sessionDataJSON) {
+        sessionData = sessionDataJSON;
+      } else {
+        sessionDataSplit = sessionDataString && sessionDataString.split('|');
+        sessionData = {
+          sessionId: parseInt(sessionDataSplit && sessionDataSplit[0], 10),
+          lastTime: parseInt(sessionDataSplit && sessionDataSplit[1], 10)
+        };
+      }
     }
 
     var sessionId = 1;


### PR DESCRIPTION
Store session ID as `67|1591909186468` rather than `{"sessionId":67,"lastTime":1591909186468}`

This will both save on space and make it easier for clients to pull sessionId out of cookie data.

Support legacy storage data structure (JSON) for session_id's to ensure backwards compatibility.

All tests pass (45/45) - 2 tests added.

Lint passes.