### PR TITLE
[CSL 392] Decode cookies individually

### DIFF
--- a/spec/006-cookies.js
+++ b/spec/006-cookies.js
@@ -37,6 +37,16 @@ describe('ConstructorioID', function () {
       var value = session.get_cookie('melikecookie');
       expect(value).to.be.undefined;
     });
+
+    it('should handle unencoded cookies gracefully', function () {
+      document.cookie = 'melikecookie=omnomnom;'
+      document.cookie = 'badly=encoded%cookie'
+
+      var session = new ConstructorioID();
+      var value = session.get_cookie('melikecookie');
+
+      expect(value).to.match(/^omnomnom$/);
+    });
   });
 
   describe('delete_cookie', function () {

--- a/spec/006-cookies.js
+++ b/spec/006-cookies.js
@@ -39,8 +39,8 @@ describe('ConstructorioID', function () {
     });
 
     it('should handle unencoded cookies gracefully', function () {
-      document.cookie = 'melikecookie=omnomnom;'
-      document.cookie = 'badly=encoded%cookie'
+      document.cookie = 'melikecookie=omnomnom';
+      document.cookie = 'badly=encoded%cookie';
 
       var session = new ConstructorioID();
       var value = session.get_cookie('melikecookie');

--- a/src/constructorio-id.js
+++ b/src/constructorio-id.js
@@ -82,6 +82,7 @@
         while (decodedCookie.charAt(0) === ' ') { // remove leading spaces
           decodedCookie = decodedCookie.substring(1);
         }
+
         if (decodedCookie.indexOf(cookieName) === 0) {
           return decodedCookie.substring(cookieName.length, decodedCookie.length);
         }

--- a/src/constructorio-id.js
+++ b/src/constructorio-id.js
@@ -72,17 +72,24 @@
 
   ConstructorioID.prototype.get_cookie = function (name) {
     var cookieName = name + '=';
-    var decodedCookie = decodeURIComponent(document.cookie);
-    var cookieBits = decodedCookie.split(';');
+    var cookieBits = document.cookie.split(';');
     for (var i = 0; i < cookieBits.length; i++) {
       var thisCookie = cookieBits[i];
-      while (thisCookie.charAt(0) === ' ') { // remove leading spaces
-        thisCookie = thisCookie.substring(1);
-      }
-      if (thisCookie.indexOf(cookieName) === 0) {
-        return thisCookie.substring(cookieName.length, thisCookie.length);
+
+      try {
+        var decodedCookie = decodeURIComponent(thisCookie);
+
+        while (decodedCookie.charAt(0) === ' ') { // remove leading spaces
+          decodedCookie = decodedCookie.substring(1);
+        }
+        if (decodedCookie.indexOf(cookieName) === 0) {
+          return decodedCookie.substring(cookieName.length, decodedCookie.length);
+        }
+      } catch (e) {
+        // do nothing
       }
     }
+
     return undefined; // eslint-disable-line
   };
 


### PR DESCRIPTION
#### Notes:
* All tests pass and added a new test
* Works properly on Scholastic and other customers
* Was a PITA to test because all of our clients (Search, Autocomplete, Core JS) uses the identity module

#### Updates:
* Update the `get_cookies` function to handle cookies individually rather than all at once
* Previously any cookies that aren't encoded properly will fail since we call `decodeURIComponent` on the entire `document.cookie` string
* Since we encode the cookies we set and only look for specific cookies, we can just ignore the ones that we don't care about by wrapping the code in a try/catch
* In Scholastic's case, they had a cookie `product-foundLT=UCOM:Summer Specials:htmlContentEditor section:Save up to 30% off the list price! SHOP ALL` that had a `%` that wasn't properly encoded which threw an error and caused the page to not load properly

<img width="626" alt="Screen Shot 2021-06-22 at 12 43 49 PM" src="https://user-images.githubusercontent.com/7194266/123006415-7652d200-d36c-11eb-80b8-d986c2242908.png">
