### PR TITLE
[CSL 550] Ensure cookie is set to root domain

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,7 @@
     "serve": "^11.3.2",
     "sinon": "^7.4.2"
   },
-  "dependencies": {}
+  "dependencies": {
+    "parse-domain": "^4.1.0"
+  }
 }

--- a/spec/006-cookies.js
+++ b/spec/006-cookies.js
@@ -22,6 +22,30 @@ describe('ConstructorioID', function () {
       var cookieData =  session.set_cookie('mewantcookie', 'meeatcookie');
       expect(cookieData).to.match(/mewantcookie=meeatcookie; expires=.*; path=\//);
     });
+
+    it('should create a cookie using the root domain if there are one or more top level domains', function () {
+      var dom = new jsdom.JSDOM('', {
+        url: 'https://www.constructor.co.uk'
+      });
+      global.window = dom.window;
+      global.document = dom.window.document;
+
+      var session = new ConstructorioID();
+      var cookieData =  session.set_cookie('mewantcookie', 'meeatcookie');
+      expect(cookieData).to.match(/mewantcookie=meeatcookie; expires=.*; path=\/; domain=constructor.co.uk/);
+    });
+
+    it('should create a cookie using the root domain if there are one or more subdomains', function () {
+      var dom = new jsdom.JSDOM('', {
+        url: 'https://subdomain1.subdomain2.constructor.com.au'
+      });
+      global.window = dom.window;
+      global.document = dom.window.document;
+
+      var session = new ConstructorioID();
+      var cookieData =  session.set_cookie('mewantcookie', 'meeatcookie');
+      expect(cookieData).to.match(/mewantcookie=meeatcookie; expires=.*; path=\/; domain=constructor.com.au/);
+    });
   });
 
   describe('get_cookie', function () {

--- a/src/constructorio-id.js
+++ b/src/constructorio-id.js
@@ -1,3 +1,5 @@
+var pd = require('parse-domain');
+
 (function () {
   // Object.assign polyfill
   // - https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Polyfill
@@ -60,6 +62,13 @@
       var cookie_data = name + '=' + value + '; expires=' + expires.toUTCString() + '; path=/';
       if (this.cookie_domain) {
         cookie_data += '; domain=' + this.cookie_domain;
+      } else if (window && window.location && window.location.hostname) {
+        var parsedResult = pd.parseDomain(window.location.hostname);
+
+        if (parsedResult.type === pd.ParseResultType.Listed) {
+          var domain = parsedResult.domain + '.' + parsedResult.topLevelDomains.join('.');
+          cookie_data += '; domain=' + domain;
+        }
       }
       document.cookie = cookie_data;
 


### PR DESCRIPTION
### How to test:
* `npm install` in constructorio-identity
* Update `package.json` in autocomplete-ui with "@constructor-io/constructorio-id": "file:<path_to_identity_module_directory>"
* `npm run clean` & `npm install` in autocomplete-ui
* `npm run build:dev` & `npm run server`
* Clear your cookies in the browser for the customer you're checking and voila, should now set the cookie domain to the root domain

### Updates:
* Bring in `parse-domain` package to help extract root domain (handles subdomains and top level domains)
* Add tests