### PR TITLE
[CSL 2370] Persist new beacon status for beacon and clientjs scenarios

### DIFF
--- a/spec/001-initialization.js
+++ b/spec/001-initialization.js
@@ -286,6 +286,7 @@ describe('ConstructorioID', function () {
       expect(session.session_id).to.equal(43);
       expect(session.session_is_new).to.be.a('boolean');
       expect(session.session_is_new).to.equal(true);
+      expect(session.new_to_beacon).to.equal(null);
     });
 
     it('should set session_is_new to false if the session is not new and storage location is set to cookie', function () {
@@ -302,18 +303,21 @@ describe('ConstructorioID', function () {
       expect(session.session_id).to.equal(43);
       expect(session.session_is_new).to.be.a('boolean');
       expect(session.session_is_new).to.equal(true);
+      expect(session.new_to_beacon).to.equal(null);
     });
 
     it('should set session_is_new to true if there is no local storage data', function () {
       var session = new ConstructorioID();
       expect(session.session_is_new).to.be.a('boolean');
       expect(session.session_is_new).to.equal(true);
+      expect(session.new_to_beacon).to.equal(null);
     });
 
     it('should set session_is_new to true if there is no cookie data and storage location is set to cookie', function () {
       var session = new ConstructorioID({ session_id_storage_location: 'cookie' });
       expect(session.session_is_new).to.be.a('boolean');
       expect(session.session_is_new).to.equal(true);
+      expect(session.new_to_beacon).to.equal(null);
     });
 
     it('should set the user agent', function () {
@@ -363,6 +367,11 @@ describe('ConstructorioID', function () {
     it('should set node status to true', function () {
       var session = new ConstructorioID();
       expect(session.on_node).to.be.true;
+    });
+
+    it('should not set new_to_beacon', function () {
+      var session = new ConstructorioID();
+      expect(session.new_to_beacon).to.be.null;
     });
   });
 });

--- a/spec/005-storage.js
+++ b/spec/005-storage.js
@@ -107,6 +107,7 @@ describe('ConstructorioID', function () {
       expect(set_local_object.getCall(0).args[1]).to.equal(43);
       expect(set_local_object.getCall(1).args[1].sessionId).to.equal(43);
       expect(set_local_object.getCall(1).args[1].lastTime).to.be.at.least(now);
+      expect(set_local_object.getCall(1).args[1].newToBeacon).to.be.true;
 
       set_local_object.restore();
     });
@@ -126,6 +127,7 @@ describe('ConstructorioID', function () {
       expect(JSON.parse(set_cookie.getCall(0).args[1])).to.equal(43);
       expect(JSON.parse(set_cookie.getCall(1).args[1]).sessionId).to.equal(43);
       expect(JSON.parse(set_cookie.getCall(1).args[1]).lastTime).to.be.at.least(now);
+      expect(JSON.parse(set_cookie.getCall(1).args[1]).newToBeacon).to.be.true;
 
       set_cookie.restore();
     });

--- a/src/constructorio-id.js
+++ b/src/constructorio-id.js
@@ -237,20 +237,29 @@
     this.session_id = sessionId;
     this.session_is_new = sessionData && sessionDataId === sessionId ? false : true;
 
+    // persist new status for when ciojs-client is instantiated before beacon
+    if (sessionData && sessionData.beaconCheck) {
+      this.beacon_new = true;
+    }
+
+    const storedData = {
+      sessionId: sessionId,
+      lastTime: now
+    };
+
+    // persist new status for when ciojs-client is instantiated before beacon
+    if (this.session_is_new) {
+      storedData.beaconCheck = true;
+    }
+
     if (this.session_id_storage_location === 'local') {
       this.set_local_object(this.local_name_session_id, sessionId);
-      this.set_local_object(this.local_name_session_data, {
-        sessionId: sessionId,
-        lastTime: now
-      });
+      this.set_local_object(this.local_name_session_data, storedData);
     }
 
     if (this.session_id_storage_location === 'cookie') {
       this.set_cookie(this.cookie_name_session_id, sessionId);
-      this.set_cookie(this.cookie_name_session_data, JSON.stringify({
-        sessionId: sessionId,
-        lastTime: now
-      }));
+      this.set_cookie(this.cookie_name_session_data, JSON.stringify(storedData));
     }
 
     return sessionId;

--- a/src/constructorio-id.js
+++ b/src/constructorio-id.js
@@ -17,6 +17,7 @@
       local_name_session_data: '_constructorio_search_session',
       on_node: typeof window === 'undefined',
       session_is_new: null,
+      is_new_to_beacon: null,
       client_id_storage_location: 'cookie',
       session_id_storage_location: 'local'
     };
@@ -238,8 +239,8 @@
     this.session_is_new = sessionData && sessionDataId === sessionId ? false : true;
 
     // persist new status for when ciojs-client is instantiated before beacon
-    if (sessionData && sessionData.beaconCheck) {
-      this.beacon_new = true;
+    if (sessionData && sessionData.isNewToBeacon) {
+      this.is_new_to_beacon = true;
     }
 
     const storedData = {
@@ -249,7 +250,7 @@
 
     // persist new status for when ciojs-client is instantiated before beacon
     if (this.session_is_new) {
-      storedData.beaconCheck = true;
+      storedData.isNewToBeacon = true;
     }
 
     if (this.session_id_storage_location === 'local') {

--- a/src/constructorio-id.js
+++ b/src/constructorio-id.js
@@ -19,7 +19,7 @@
       local_name_session_data: '_constructorio_search_session',
       on_node: typeof window === 'undefined',
       session_is_new: null,
-      is_new_to_beacon: null,
+      new_to_beacon: null,
       client_id_storage_location: 'cookie',
       session_id_storage_location: 'local'
     };
@@ -247,8 +247,8 @@
     this.session_is_new = sessionData && sessionDataId === sessionId ? false : true;
 
     // persist new status for when ciojs-client is instantiated before beacon
-    if (sessionData && sessionData.isNewToBeacon) {
-      this.is_new_to_beacon = true;
+    if (sessionData && sessionData.newToBeacon) {
+      this.new_to_beacon = true;
     }
 
     const storedData = {
@@ -258,7 +258,7 @@
 
     // persist new status for when ciojs-client is instantiated before beacon
     if (this.session_is_new) {
-      storedData.isNewToBeacon = true;
+      storedData.newToBeacon = true;
     }
 
     if (this.session_id_storage_location === 'local') {


### PR DESCRIPTION
- Session start event does not fire due to the client-js instantiating its own identity module and throws off the `session_is_new` logic
- Create new field to persist `session_is_new` value for these scenarios
- Needs to be deployed before https://github.com/Constructor-io/autocomplete-ui/pull/2573